### PR TITLE
Fix test being flaky on macOS

### DIFF
--- a/tests/util.rs
+++ b/tests/util.rs
@@ -328,7 +328,7 @@ impl TestCommand {
             .expect("Failed to spawn the process");
 
         // Allow the process sufficient time to start and set up Ctrl-C handler
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        thread::sleep(Duration::from_millis(500));
 
         let pid = Pid::from_raw(child.id() as i32);
         signal::kill(pid, Signal::SIGINT).expect("Failed to send SIGINT");


### PR DESCRIPTION
It seems like startup time is longer on macOS, so the process will be killed before properly having been set up, thus not passing the test. I haven't seen this on Linux / Github Actions so I'm assuming it's a macOS specific thing.